### PR TITLE
Laravel 7.0 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,19 @@
 
 A Laravel Spark front-end scaffolding preset for [Tailwind CSS](https://tailwindcss.com) - a Utility-First CSS Framework for Rapid UI Development.
 
-## 1. Usage
+## 1. Usage with Laravel 6.0
 
 1. Fresh install Laravel >= 6.0 and Spark >= 9.0 and `cd` to your app.
-2. Install this preset via `composer require centrality-labs/spark-tailwindcss --dev`. Laravel will automatically discover this package. No need to register the service provider
+2. Install this preset via `composer require centrality-labs/spark-tailwindcss:1.0.0 --dev`. Laravel will automatically discover this package. No need to register the service provider
 3. Use `php artisan preset spark-tailwindcss` for the basic Tailwind CSS preset
+4. `npm install && npm run dev`
+5. `php artisan serve` (or equivalent) to run server and test preset.
+
+## 1. Usage with Laravel 7.0
+
+1. Fresh install Laravel >= 7.0 and Spark >= 9.0 and `cd` to your app.
+2. Install this preset via `composer require centrality-labs/spark-tailwindcss:2.0.0 --dev`. Laravel will automatically discover this package. No need to register the service provider
+3. Use `php artisan ui spark-tailwindcss` for the basic Tailwind CSS preset
 4. `npm install && npm run dev`
 5. `php artisan serve` (or equivalent) to run server and test preset.
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
   "keywords": ["laravel", "spark", "preset", "tailwindcss"],
   "license": "MIT",
   "require": {
-    "laravel/framework": "^5.5 || ^6.0"
+    "laravel/framework": "^7.0",
+    "laravel/ui": "^2.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/SparkTailwindCssPreset.php
+++ b/src/SparkTailwindCssPreset.php
@@ -3,9 +3,7 @@
 namespace CentralityLabs\SparkTailwindCssPreset;
 
 use Illuminate\Support\Arr;
-use Illuminate\Container\Container;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Foundation\Console\Presets\Preset;
 use Laravel\Ui\Presets\Preset;
 
 class SparkTailwindCssPreset extends Preset

--- a/src/SparkTailwindCssPreset.php
+++ b/src/SparkTailwindCssPreset.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Container\Container;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Console\Presets\Preset;
+use Laravel\Ui\Presets\Preset;
 
 class SparkTailwindCssPreset extends Preset
 {

--- a/src/SparkTailwindCssPresetServiceProvider.php
+++ b/src/SparkTailwindCssPresetServiceProvider.php
@@ -5,12 +5,13 @@ namespace CentralityLabs\SparkTailwindCssPreset;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Foundation\Console\PresetCommand;
+use Laravel\Ui\UiCommand;
 
 class SparkTailwindCssPresetServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        PresetCommand::macro('spark-tailwindcss', function ($command) {
+        UiCommand::macro('spark-tailwindcss', function ($command) {
             SparkTailwindCssPreset::install();
 
             $command->info('Tailwind CSS scaffolding for Laravel Spark installed successfully.');


### PR DESCRIPTION
Migrated from using `php artisan presets` to `php artisan ui` to enable support for Laravel 7.0. 

This is a breaking change and will mean the version will bump to 2.0.0 